### PR TITLE
feat(pre-mount-gptprio): die if the kexec returns

### DIFF
--- a/dracut/80gptprio/pre-mount-gptprio.sh
+++ b/dracut/80gptprio/pre-mount-gptprio.sh
@@ -15,6 +15,10 @@ find_root() {
     mount -o ro /dev/disk/by-partuuid/${root_lower} /tmp/boot
     kexec --command-line="${cmd_line} root=PARTUUID=${root_upper}" -l /tmp/boot/boot/vmlinuz
     kexec -e
+    echo "ERROR: bootengine: kexec -e shouldn't return!"
+    echo "cmd_line was $cmd_line"
+    echo "root_upper was $root_upper"
+    exit 1
 }
 
 if [ -n "$root" -a -z "${root%%gptprio:}" ]; then


### PR DESCRIPTION
kexec is like exec in that we should never return. If we do return then
something terrible happened. Lets stop everything and print an error.
