### PR TITLE
fix(dracut): use lower on PARTUUID

### DIFF
--- a/dracut/80gptprio/pre-mount-gptprio.sh
+++ b/dracut/80gptprio/pre-mount-gptprio.sh
@@ -62,7 +62,7 @@ cgpt_next() {
     info "bootengine: selected PARTUUID $root_upper"
 
     BOOTENGINE_ROOT="/dev/disk/by-partuuid/${root_lower}"
-    BOOTENGINE_ROOT_CMDLINE="PARTUUID=${root_upper}"
+    BOOTENGINE_ROOT_CMDLINE="PARTUUID=${root_lower}"
 }
 
 do_exec_or_find_root() {


### PR DESCRIPTION
although the source code docs in the kernel shows only uppercase letters
in the uuids for root=PARTUUID arguments both are supported. However,
dracut only supports lower case. So, use lowercase.
