### PR TITLE
fix(module-setup): Use dracut_install which aborts on errors.

### DIFF
--- a/dracut/80gptprio/module-setup.sh
+++ b/dracut/80gptprio/module-setup.sh
@@ -7,10 +7,10 @@ depends() {
 }
 
 install() {
-    inst /usr/bin/cgpt
-    inst /usr/sbin/kexec
-    inst /usr/bin/old_bins/cgpt
-    inst /usr/bin/tr
+    dracut_install /usr/bin/cgpt
+    dracut_install /usr/sbin/kexec
+    dracut_install /usr/bin/old_bins/cgpt
+    dracut_install /usr/bin/tr
     inst_hook cmdline 80 "$moddir/parse-gptprio.sh"
     inst_hook pre-mount 80 "$moddir/pre-mount-gptprio.sh"
 }


### PR DESCRIPTION
dracut_install is a wrapper around inst which aborts with error messages
when a source is missing while inst simply returns non-zero. inst let
us get away with building bootengine with missing deps and not noticing.
