### PR TITLE
feat(parse-squashfs): add in support for custom OEMs

### DIFF
--- a/dracut/80squashfs/parse-squashfs.sh
+++ b/dracut/80squashfs/parse-squashfs.sh
@@ -5,4 +5,11 @@
 if [ "${root%%:*}" = "squashfs" ]; then
     rootok=1
     mount -t squashfs newroot.squashfs $NEWROOT && { [ -e /dev/root ] || ln -s null /dev/root ; }
+
+    # TODO: Separate this out into a separate step
+    if [ -d /usr/share/oem ]; then
+        mkdir -p $NEWROOT/usr/share/oem
+        mount -t tmpfs -o size=128m tmpfs $NEWROOT/usr/share/oem
+        cp -Ra /usr/share/oem/. $NEWROOT/usr/share/oem
+    fi
 fi


### PR DESCRIPTION
PXE images are a bit tricky because you only have two pieces of information to
work with: the kernel and the initramfs. The eventual plan is for the kernel
and initramfs to be one file on CoreOS. This leaves the cpio free for user
customization. So, we will allow users to put their own OEM customizations
into this dir.

The way this will work is that if there is a /usr/share/oem in the initramfs
then we mount a tmpfs on $NEWROOT/usr/share/oem
