### PR TITLE
fix(80squashfs): Split hook into separate parse and mount hooks.

### DIFF
--- a/dracut/80squashfs/module-setup.sh
+++ b/dracut/80squashfs/module-setup.sh
@@ -7,9 +7,10 @@ depends() {
 }
 
 installkernel() {
-    instmods squashfs
+    instmods loop squashfs
 }
 
 install() {
     inst_hook cmdline 80 "$moddir/parse-squashfs.sh"
+    inst_hook mount 80 "$moddir/mount-squashfs.sh"
 }

--- a/dracut/80squashfs/mount-squashfs.sh
+++ b/dracut/80squashfs/mount-squashfs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+if [ "${root%%:*}" = "squashfs" ]; then
+    mount -t squashfs newroot.squashfs $NEWROOT && { [ -e /dev/root ] || ln -s null /dev/root ; }
+
+    # TODO: Separate this out into a separate step
+    if [ -d /usr/share/oem ]; then
+        mkdir -p $NEWROOT/usr/share/oem
+        mount -t tmpfs -o size=0,mode=755,uid=0,gid=0 tmpfs $NEWROOT/usr/share/oem
+        cp -Ra /usr/share/oem/. $NEWROOT/usr/share/oem
+    fi
+fi

--- a/dracut/80squashfs/parse-squashfs.sh
+++ b/dracut/80squashfs/parse-squashfs.sh
@@ -4,12 +4,4 @@
 
 if [ "${root%%:*}" = "squashfs" ]; then
     rootok=1
-    mount -t squashfs newroot.squashfs $NEWROOT && { [ -e /dev/root ] || ln -s null /dev/root ; }
-
-    # TODO: Separate this out into a separate step
-    if [ -d /usr/share/oem ]; then
-        mkdir -p $NEWROOT/usr/share/oem
-        mount -t tmpfs -o size=0,mode=755,uid=0,gid=0 tmpfs $NEWROOT/usr/share/oem
-        cp -Ra /usr/share/oem/. $NEWROOT/usr/share/oem
-    fi
 fi


### PR DESCRIPTION
The parse step is too early, the system isn't initialized enough to
mount squashfs. Namely /dev/loop\* devices may not have been created yet.

Tested and verified to fix the issue by running qemu with better processor options: -cpu host -smp 8
