### PR TITLE
feat(80usrgptprio) add ability for unique /etc/machine-id files

### DIFF
--- a/dracut/80usrgptprio/module-setup.sh
+++ b/dracut/80usrgptprio/module-setup.sh
@@ -7,7 +7,7 @@ depends() {
 }
 
 install() {
-    dracut_install awk tr
+    dracut_install awk tr grep systemd-machine-id-setup
     dracut_install /usr/bin/cgpt
     dracut_install /usr/sbin/kexec
     dracut_install /usr/bin/old_bins/cgpt


### PR DESCRIPTION
At first boot, we will create a new /etc/machine-id file to make the
machine "unique".  If the file is not there, or empty, or conaining
things that do not make up a valid machine-id file, we will delete the
offending file and recreate it.

Thanks to @marineam for the hint to use grep to make things simpler.
