### PR TITLE
fix(update-bootengine): Exclude unnecessary dracut modules.

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -24,7 +24,16 @@ new filesystem namespace when operating inside the chroot, that way anything
 bad that happens will be less likely to hurt the host system. But no promises!
 "
 
-DRACUT_ARGS=(--force --no-kernel --fstab --no-compress)
+DRACUT_ARGS=(
+    --force
+    --no-hostonly
+    --no-kernel
+    --no-compress
+    --omit i18n
+    --omit lvm
+    --omit network
+    --omit terminfo
+    )
 
 SETUP_MOUNTS=
 USE_CHROOT=


### PR DESCRIPTION
Newer dracut ebuilds install all available modules so it is just up to
dracut's auto-detection to determine what modules it can include.
Excluding networking, lvm, and terminfo drops the size from 35M to 18M.
