### PR TITLE
systemd: add module to disable network device renaming

### DIFF
--- a/dracut/80disable-net-names/module-setup.sh
+++ b/dracut/80disable-net-names/module-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd
+}
+
+install() {
+    # Override the default link to disable the NamePolciy, that way
+    # device names remain untouched until the real system boots.
+    mkdir -p "$initdir/etc/systemd/network"
+    {
+        echo "[Link]"
+        echo "NamePolicy="
+        echo "MACAddressPolicy=persistent"
+    } >> "$initdir/etc/systemd/network/98-disable-net-names.link"
+}


### PR DESCRIPTION
This should make it a little easier to control this behavior by waiting
until the real system boots to enable this policy.
