### PR TITLE
gptprio: retry mount if it fails the first time

### DIFF
--- a/dracut/80gptprio/tests/fixtures.sh
+++ b/dracut/80gptprio/tests/fixtures.sh
@@ -61,6 +61,10 @@ systemctl() {
     fail "$@"
 }
 
+udevadm() {
+    echo "udevadm $@"
+}
+
 cgpt() {
     if [ "$1" != "next" ]; then
         fail "unexpected cgpt call"


### PR DESCRIPTION
cgpt next writes the disk's partition table but does not trigger a
partition rescan. This is desirable because the change is trivial and we
need to trust that the kernel and udev has already finished setting up
device nodes and symlinks for the disk partitions so we can mount.

Unfortunately starting with 215 udev detects the write from cgpt and
triggers change events for all partitions. Previously it only triggered
events for the disk device, not all partitions, so our partition node
and symlinks were relatively safe. Commit here:

https://github.com/systemd/systemd/commit/f3a740a5dae792fb6b2d411022ce8c29ced1c3f1

In theory udevadm settle helps with this but only if the change events
have been added to its queue, if we use settle too soon it may exit
before udev triggers the change event. I don't know how to prevent this.
So my solution for now is to try settle and mount a second time if the
first mount fails due to a missing device. ಠ_ಠ
