### PR TITLE
update-bootengine: always run ldconfig in chroots before dracut

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -97,6 +97,7 @@ fi
 mkdir -p "${USE_CHROOT}$(dirname "$CPIO_PATH")"
 if [[ -n "$USE_CHROOT" ]]; then
     echo "Running dracut in $USE_CHROOT"
+    LC_ALL=C ldconfig -X -r "$USE_CHROOT"
     LC_ALL=C chroot "$USE_CHROOT" dracut "${DRACUT_ARGS[@]}" "$CPIO_PATH"
 else
     echo "Running dracut in root"


### PR DESCRIPTION
Portage is not good about updating ld.so.cache when installing packages
to alternate ROOTs. To ensure we are not operating with an old or
missing cache always run ldconfig before dracut. Helpfully dracut does
not fail when it cannot find some shared libraries, allowing it to
create completely broken initrds.
