### PR TITLE
systemd: don't initialize machine-id, do initialize ld.so.conf

### DIFF
--- a/dracut/80setup-root/module-setup.sh
+++ b/dracut/80setup-root/module-setup.sh
@@ -7,6 +7,6 @@ depends() {
 }
 
 install() {
-    dracut_install grep systemd-machine-id-setup systemd-tmpfiles
+    dracut_install grep ldconfig systemd-tmpfiles
     inst_hook pre-pivot 80 "$moddir/pre-pivot-setup-root.sh"
 }


### PR DESCRIPTION
systemd for a while now has properly initialized machine-id if the file
is missing or blank. Switch to letting it do that by removing or bogus
machine id if it is present.

systemd does not always set up ld.so.conf early enough, switch to doing
so in the initrd. This removes the need for one of our systemd patches.
