### PR TITLE
setup-root: remove call to ldconfig

### DIFF
--- a/dracut/80setup-root/pre-pivot-setup-root.sh
+++ b/dracut/80setup-root/pre-pivot-setup-root.sh
@@ -32,7 +32,6 @@ do_setup_root() {
     if [ -e "/sysroot/usr/lib/tmpfiles.d/baselayout-ldso.conf" ]; then
         bootengine_cmd systemd-tmpfiles --root=/sysroot --create \
             baselayout-ldso.conf
-        bootengine_cmd ldconfig -X -r /sysroot
     fi
 
     # Remove our phony id. systemd will initialize this during boot.


### PR DESCRIPTION
Recently added in commit 82b6d9ee, in addition to initializing
ld.so.conf that commit initialized ld.so.cache on each boot.
Unfortunately this may clobber references to libraries in /usr/share/oem
which is not mounted by the initrd. systemd provides ldconfig.service to
perform this task and selectively runs it on boots after upgrades after
/usr/share/oem is mounted. In production images all libraries
required to boot as far as sysinit.target are in the default library
path so we can get away without ld.so.cache until ldconfig.service runs.

Fixes https://github.com/coreos/bugs/issues/216
