### PR TITLE
verity-generator: disable default dependencies

### DIFF
--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -65,6 +65,7 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	[Unit]
 	SourcePath=/proc/cmdline
 	Description=create a dm-verity device for usr partition
+	DefaultDependencies=no
 	Before=sysroot-usr.mount
 	Requires=${device}
 	After=${device}


### PR DESCRIPTION
By default services depend on `basic.target` but this is problematic for
anything directly in the dependency tree for `initrd-switch-root.target`
as it means everything under `basic.target` will not be stopped prior to
the switch root. This leads to all sorts of surprising things, including
stalling boot because `systemd-udev-trigger.service` fails to run after
switch-root, leaving udev with incomplete state.