### PR TITLE
dracut: add Ignition

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    inst_multiple \
+        ignition \
+        "$udevdir/rules.d/90-ignition.rules" \
+        "$systemdsystemunitdir/mnt-oem.mount" \
+        "$systemdsystemunitdir/ignition.target" \
+        "$systemdsystemunitdir/ignition-disks.service" \
+        "$systemdsystemunitdir/ignition-files.service"
+}


### PR DESCRIPTION
--omit-network has been removed so that kernel options like
"ip=eth0:dhcp" are processed in the initrd. Networking may be needed for
Ignition to fetch the user_data.