### PR TITLE
table-guid: add service for generating GPT GUID

### DIFF
--- a/dracut/30disk-uuid/90-disk-uuid.rules
+++ b/dracut/30disk-uuid/90-disk-uuid.rules
@@ -1,0 +1,16 @@
+# persistent storage links: /dev/disk/by-diskuuid
+# scheme based on "Linux persistent device names", 2004, Hannes Reinecke <hare@suse.de>
+
+ACTION=="remove", GOTO="disk_uuid_end"
+
+SUBSYSTEM!="block", GOTO="disk_uuid_end"
+
+ENV{DEVTYPE}!="disk", GOTO="disk_uuid_end"
+
+# rename the disk UUID if it is the default
+ENV{ID_PART_TABLE_UUID}=="00000000-0000-0000-0000-000000000001", TAG+="systemd", ENV{SYSTEMD_WANTS}+="disk-uuid.service"
+
+# by-diskuuid links (partition metadata)
+ENV{ID_PART_TABLE_TYPE}=="gpt", ENV{ID_PART_TABLE_UUID}=="?*", SYMLINK+="disk/by-diskuuid/$env{ID_PART_TABLE_UUID}"
+
+LABEL="disk_uuid_end"

--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Generate new UUID for disk GPT
+DefaultDepedencies=no
+Requires=ignition.target
+After=ignition.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/sgdisk --disk-guid=R /dev/disk/by-diskuuid/00000000-0000-0000-0000-000000000001

--- a/dracut/30disk-uuid/module-setup.sh
+++ b/dracut/30disk-uuid/module-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    inst sgdisk
+    inst "$moddir/disk-uuid.service" "$systemdsystemunitdir/disk-uuid.service"
+    inst_rules "$moddir/90-disk-uuid.rules"
+}


### PR DESCRIPTION
On first boot, the GPT table GUID will be set to
00000000-0000-0000-0000-000000000001. This service will generate a
proper GUID if the table GUID is still the default and after Ignition
has run. It is run after Ignition so that in the event that Ignition
fails to run, it won't successfully boot after a reboot.