### PR TITLE
dracut: add ordering on disk-uuid.service

### DIFF
--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Generate new UUID for disk GPT
 DefaultDependencies=no
+Wants=local-fs-pre.target
+Before=local-fs-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
disk-uuid.service was racing with disk fscks and causing boot failures.
This was due to the GPT change triggering a udev partition re-scan
(which removes device symlinks) while the fsck was in progress.