### PR TITLE
dracut: discard 99-default.link from 02systemd-networkd module

### DIFF
--- a/dracut/02systemd-networkd/99-default.link
+++ b/dracut/02systemd-networkd/99-default.link
@@ -1,3 +1,0 @@
-[Link]
-NamePolicy=kernel database onboard slot path
-MACAddressPolicy=persistent

--- a/dracut/02systemd-networkd/module-setup.sh
+++ b/dracut/02systemd-networkd/module-setup.sh
@@ -15,9 +15,6 @@ install() {
     inst_simple "$moddir/initrd-systemd-resolved.service" \
         "$systemdsystemunitdir/initrd-systemd-resolved.service"
     
-    inst_simple "$moddir/99-default.link" \
-        "$systemdutildir/network/99-default.link"
-    
     inst_simple "$moddir/zz-default.network" \
         "$systemdutildir/network/zz-default.network"
 


### PR DESCRIPTION
The 80disable-net-names module installs 98-disable-net-names.link which
takes precedence over and conflicts with 99-default.link.

Just drop 99-default.link from the 02systemd-networkd module.