### PR TITLE
dracut: take down all interfaces before switchroot

### DIFF
--- a/dracut/02systemd-networkd/initrd-systemd-networkd.service
+++ b/dracut/02systemd-networkd/initrd-systemd-networkd.service
@@ -34,6 +34,7 @@ ProtectHome=yes
 WatchdogSec=1min
 
 ExecStop=/usr/bin/ip addr flush up
+ExecStop=/usr/bin/ip link set group default down
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The interfaces need to be reset to a pre-boot state so that userspace
after the switchroot can properly configure the interfaces.