### PR TITLE
dracut: udevadm settle after writing the disk GUID

### DIFF
--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -3,7 +3,10 @@ Description=Generate new UUID for disk GPT
 DefaultDependencies=no
 Wants=local-fs-pre.target
 Before=local-fs-pre.target
+Wants=systemd-udevd.service
+After=systemd-udevd.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/sgdisk --disk-guid=R /dev/disk/by-diskuuid/00000000-0000-0000-0000-000000000001
+ExecStart=/usr/bin/udevadm settle


### PR DESCRIPTION
To prevent disk-manipulating services ordered against disk-uuid.service
from racing with udev manipulating the associated device symlinks, settle
immediately after we write the GUID.