### PR TITLE
dracut: set DefaultDependencies=no for initrd-systemd-resolved

### DIFF
--- a/dracut/02systemd-networkd/initrd-systemd-resolved.service
+++ b/dracut/02systemd-networkd/initrd-systemd-resolved.service
@@ -9,6 +9,7 @@
 Description=Network Name Resolution
 Documentation=man:systemd-resolved.service(8)
 ConditionPathExists=/etc/initrd-release
+DefaultDependencies=no
 After=initrd-systemd-networkd.service network.target
 
 # On kdbus systems we pull in the busname explicitly, because it


### PR DESCRIPTION
This was causing a dependency cycle when coreos.ignition.force was
specified.