### PR TITLE
Set up selinux tmpfiles before switching to root pivot

### DIFF
--- a/dracut/80setup-root/pre-pivot-setup-root.sh
+++ b/dracut/80setup-root/pre-pivot-setup-root.sh
@@ -21,7 +21,8 @@ bootengine_cmd() {
 do_setup_root() {
     # Initialize base filesystem
     bootengine_cmd systemd-tmpfiles --root=/sysroot --create \
-        baselayout.conf baselayout-etc.conf baselayout-usr.conf
+        baselayout.conf baselayout-etc.conf baselayout-usr.conf \
+        libsemanage.conf selinux-base.conf
 
     # Not all images provide this file so check before using it.
     if [ -e "/sysroot/usr/lib/tmpfiles.d/baselayout-ldso.conf" ]; then


### PR DESCRIPTION
The selinux symlinks need to exist before systemd is re-execed in order
to ensure that systemd can find and load the selinux policy.