### PR TITLE
bootengine: add local-fs-pre.target to systemd-fsck@.service.wants

### DIFF
--- a/dracut/99fsck-wants-local-fs-pre/module-setup.sh
+++ b/dracut/99fsck-wants-local-fs-pre/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    # Want local-fs-pre.target by the fscks to ensure they get ordered
+    # after it.
+    #
+    # Without this we may begin fscks before local-fs-pre.target becomes
+    # activated, rendering the already present "After local-fs-pre.target"
+    # ineffective, which can result in fscks occurring simultaneous to
+    # ignition-disks.
+
+    mkdir -p "${initdir}/${systemdsystemunitdir}/systemd-fsck@.service.wants"
+    ln_r "${systemdsystemunitdir}/local-fs-pre.target" \
+        "${systemdsystemunitdir}/systemd-fsck@.service.wants/local-fs-pre.target"
+}


### PR DESCRIPTION
This is to prevent the possibility of fsck during ignition-disks, which
is ordered before local-fs-pre.target.

systemd-fsck@.service was already ordered after local-fs-pre.target but
had no wants or requires of it, leaving the potential for fsck to start
before local-fs-pre.target becomes activated.