### PR TITLE
Backport disk-uuid fixes to a pre-ignition revision

### DIFF
--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Generate new UUID for disk GPT
 DefaultDependencies=no
+Wants=local-fs-pre.target
+Before=local-fs-pre.target
 
 [Service]
 Type=oneshot

--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -3,7 +3,10 @@ Description=Generate new UUID for disk GPT
 DefaultDependencies=no
 Wants=local-fs-pre.target
 Before=local-fs-pre.target
+Wants=systemd-udevd.service
+After=systemd-udevd.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/sgdisk --disk-guid=R /dev/disk/by-diskuuid/00000000-0000-0000-0000-000000000001
+ExecStart=/usr/bin/udevadm settle


### PR DESCRIPTION
The 766 branch is now excluding ignition but we still need disk-uuid so pull in its fixes.