### PR TITLE
dracut: remove junk from zz-default.network

### DIFF
--- a/dracut/02systemd-networkd/zz-default.network
+++ b/dracut/02systemd-networkd/zz-default.network
@@ -1,6 +1,3 @@
-[Unit]
-ConditionPathExists=/etc/initrd-release
-
 [Network]
 DHCP=v4
 LinkLocalAddressing=yes


### PR DESCRIPTION
This snuck in from experimentation and should never have been merged.
It's being ignored by systemd-networkd, since .network files not
actually systemd units.