### PR TITLE
dracut: remove link-local addr from network config

### DIFF
--- a/dracut/02systemd-networkd/zz-default.network
+++ b/dracut/02systemd-networkd/zz-default.network
@@ -1,6 +1,5 @@
 [Network]
 DHCP=v4
-LinkLocalAddressing=yes
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
This is screwing with EC2's networking.