### PR TITLE
dracut: apply etc.conf in initrd-setup-root

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -10,7 +10,7 @@ do_setup_root() {
     # Initialize base filesystem
     systemd-tmpfiles --root=/sysroot --create \
         baselayout.conf baselayout-etc.conf baselayout-usr.conf \
-        baselayout-home.conf libsemanage.conf selinux-base.conf
+        baselayout-home.conf etc.conf libsemanage.conf selinux-base.conf
 
     # Not all images provide this file so check before using it.
     if [ -e "/sysroot/usr/lib/tmpfiles.d/baselayout-ldso.conf" ]; then


### PR DESCRIPTION
As of systemd v225 mount no longer is invoked with -n making the /etc/mtab
symlink necessary from an early stage.

Fixes https://github.com/coreos/bugs/issues/463