### PR TITLE
initrd-setup-root: check selinux tmpfiles configs before using them

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -10,13 +10,14 @@ do_setup_root() {
     # Initialize base filesystem
     systemd-tmpfiles --root=/sysroot --create \
         baselayout.conf baselayout-etc.conf baselayout-usr.conf \
-        baselayout-home.conf etc.conf libsemanage.conf selinux-base.conf
+        baselayout-home.conf etc.conf
 
-    # Not all images provide this file so check before using it.
-    if [ -e "/sysroot/usr/lib/tmpfiles.d/baselayout-ldso.conf" ]; then
-        systemd-tmpfiles --root=/sysroot --create \
-            baselayout-ldso.conf
-    fi
+    # Not all images provide these files so check before using them.
+    for config in baselayout-ldso.conf libsemanage.conf selinux-base.conf; do
+        if [ -e "/sysroot/usr/lib/tmpfiles.d/${config}" ]; then
+            systemd-tmpfiles --root=/sysroot --create "${config}"
+        fi
+    done
 
     # This creates the modifiable users/groups in /sysroot/etc,
     # initializing the shadow database in the process.


### PR DESCRIPTION
Our arm64 builds do not include SELinux and if this tmpfiles job fails
ignition fails causing the first boot to drop into an emergency shell.