### PR TITLE
dracut: use ignition-generator to require disk-uuid.service

### DIFF
--- a/dracut/30disk-uuid/90-disk-uuid.rules
+++ b/dracut/30disk-uuid/90-disk-uuid.rules
@@ -7,9 +7,6 @@ SUBSYSTEM!="block", GOTO="disk_uuid_end"
 
 ENV{DEVTYPE}!="disk", GOTO="disk_uuid_end"
 
-# rename the disk UUID if it is the default
-ENV{ID_PART_TABLE_UUID}=="00000000-0000-0000-0000-000000000001", TAG+="systemd", ENV{SYSTEMD_WANTS}+="disk-uuid.service"
-
 # by-diskuuid links (partition metadata)
 ENV{ID_PART_TABLE_TYPE}=="gpt", ENV{ID_PART_TABLE_UUID}=="?*", SYMLINK+="disk/by-diskuuid/$env{ID_PART_TABLE_UUID}"
 

--- a/dracut/30disk-uuid/disk-uuid.service
+++ b/dracut/30disk-uuid/disk-uuid.service
@@ -5,6 +5,8 @@ Wants=local-fs-pre.target
 Before=local-fs-pre.target
 Wants=systemd-udevd.service
 After=systemd-udevd.service
+Requires=dev-disk-by\x2ddiskuuid-00000000\x2d0000\x2d0000\x2d0000\x2d000000000001.device
+After=dev-disk-by\x2ddiskuuid-00000000\x2d0000\x2d0000\x2d0000\x2d000000000001.device
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -34,6 +34,7 @@ add_requires() {
 
 if $(cmdline_bool coreos.first_boot 0); then
     add_requires ignition.target
+    add_requires disk-uuid.service
 fi
 
 echo "OEM_ID=$(cmdline_arg coreos.oem.id pxe)" > /run/ignition.env


### PR DESCRIPTION
Having udev add the disk-uuid.service want on-the-fly is racy.  Its
ordering will be ignored until wanted, so things like systemd-fsck-root
may get started before and run simultaneous to disk-uuid.service causing
random acts of badness.