### PR TITLE
dracut: explicitly order disk-uuid before systemd-fsck-root

### DIFF
--- a/dracut/30disk-uuid/disk-uuid@.service
+++ b/dracut/30disk-uuid/disk-uuid@.service
@@ -2,7 +2,7 @@
 Description=Generate new UUID for disk GPT %I
 DefaultDependencies=no
 Wants=local-fs-pre.target
-Before=local-fs-pre.target
+Before=local-fs-pre.target systemd-fsck-root.service
 Wants=systemd-udevd.service
 After=systemd-udevd.service
 Requires=%i.device


### PR DESCRIPTION
Without this, systemd-fsck-root.service and disk-uuid.service get
started simultaneously when the root disk gets plugged.  Then
systemd-fsck-root.service fires *again* after sgdisk closes the device.

With this, disk-uuid.service runs to completion when the root disk is
plugged, before systemd-fsck-root.service, which not only prevents
potential overlap of execution but also eliminates the double fsck.