### PR TITLE
dracut: run tmpfilesd with var and shadow configs

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -10,7 +10,7 @@ do_setup_root() {
     # Initialize base filesystem
     systemd-tmpfiles --root=/sysroot --create \
         baselayout.conf baselayout-etc.conf baselayout-usr.conf \
-        baselayout-home.conf etc.conf
+        baselayout-home.conf etc.conf etc-shadow.conf
 
     # Not all images provide these files so check before using them.
     # Note: selinux-base.conf must run before libsemanage.conf


### PR DESCRIPTION
It it possible for Ignition to manipulate users and groups via coreutils.
groupadd, for example, requires /etc/login.defs which is provided by
shadow.conf. shadow.conf requires /var/log which is created by var.conf. Include
both of these configs so that coreutils and Ignition can run.

Fixes https://github.com/coreos/bugs/issues/994.