### PR TITLE
bootengine: enable network and url-lib

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -31,8 +31,9 @@ DRACUT_ARGS=(
     --no-compress
     --omit i18n
     --omit lvm
-    --omit network
     --omit terminfo
+    # to drag in ca-certficates.crt for ignition
+    --add url-lib
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
ignition runs in the initrd, and it needs access to a certificate chain
to fetch stuff over https. url-lib drags that in through curl, and that
depends on network.