### PR TITLE
dracut: add forward-to-console option to journald

### DIFF
--- a/dracut/99journald-conf/00-forward-to-console.conf
+++ b/dracut/99journald-conf/00-forward-to-console.conf
@@ -1,0 +1,2 @@
+[Journal]
+ForwardToConsole=yes

--- a/dracut/99journald-conf/module-setup.sh
+++ b/dracut/99journald-conf/module-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd
+}
+
+install() {
+    inst_simple "$moddir/00-forward-to-console.conf" \
+        "/etc/systemd/journald.conf.d/00-forward-to-console.conf"
+}


### PR DESCRIPTION
Following up from https://github.com/coreos/coreos-overlay/pull/1823.