### PR TITLE
setup-root: fix ordering with /sysroot/usr mount

### DIFF
--- a/dracut/99setup-root/initrd-setup-root
+++ b/dracut/99setup-root/initrd-setup-root
@@ -6,33 +6,26 @@
 COREOS_BLANK_MACHINE_ID="42000000000000000000000000000042"
 MACHINE_ID_FILE="/sysroot/etc/machine-id"
 
-do_setup_root() {
-    # Initialize base filesystem
-    systemd-tmpfiles --root=/sysroot --create \
-        baselayout.conf baselayout-etc.conf baselayout-usr.conf \
-        baselayout-home.conf etc.conf etc-shadow.conf
+# Initialize base filesystem
+systemd-tmpfiles --root=/sysroot --create \
+    baselayout.conf baselayout-etc.conf baselayout-usr.conf \
+    baselayout-home.conf etc.conf etc-shadow.conf
 
-    # Not all images provide these files so check before using them.
-    # Note: selinux-base.conf must run before libsemanage.conf
-    for config in baselayout-ldso.conf selinux-base.conf libsemanage.conf; do
-        if [ -e "/sysroot/usr/lib/tmpfiles.d/${config}" ]; then
-            systemd-tmpfiles --root=/sysroot --create "${config}"
-        fi
-    done
-
-    # This creates the modifiable users/groups in /sysroot/etc,
-    # initializing the shadow database in the process.
-    /usr/sbin/coreos-tmpfiles /sysroot
-
-    # Remove our phony id. systemd will initialize this during boot.
-    if grep -qs "${COREOS_BLANK_MACHINE_ID}" "${MACHINE_ID_FILE}"; then
-        rm "${MACHINE_ID_FILE}"
+# Not all images provide these files so check before using them.
+# Note: selinux-base.conf must run before libsemanage.conf
+for config in baselayout-ldso.conf selinux-base.conf libsemanage.conf; do
+    if [ -e "/sysroot/usr/lib/tmpfiles.d/${config}" ]; then
+        systemd-tmpfiles --root=/sysroot --create "${config}"
     fi
-}
+done
 
-# Skip if root and root/usr are not mount points
-if mountpoint --quiet /sysroot && mountpoint --quiet /sysroot/usr; then
-    do_setup_root
+# This creates the modifiable users/groups in /sysroot/etc,
+# initializing the shadow database in the process.
+/usr/sbin/coreos-tmpfiles /sysroot
+
+# Remove our phony id. systemd will initialize this during boot.
+if grep -qs "${COREOS_BLANK_MACHINE_ID}" "${MACHINE_ID_FILE}"; then
+    rm "${MACHINE_ID_FILE}"
 fi
 
 # PXE initrds may provide OEM

--- a/dracut/99setup-root/initrd-setup-root.service
+++ b/dracut/99setup-root/initrd-setup-root.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Root filesystem setup
 DefaultDependencies=no
-
+RequiresMountsFor=/sysroot/usr/share/oem
 After=initrd-root-fs.target
 Before=initrd-parse-etc.service
 


### PR DESCRIPTION
First off, the script had a little bit of forgotten logic is left over
the read-only root and kexec days when things were much weirder and
allowing the setup to noop if /sysroot/usr wasn't mounted. This was
harmless until systemd 229 which includes the following change:

https://github.com/systemd/systemd/commit/104bc12fbc23c3ca852d9d389805c615cd590d01

So the fix is two fold: remove that bogus bit of logic so the setup
script explodes appropriately when /sysroot or /sysroot/usr isn't
mounted. Additionally fix the actual bug by ordering after
initrd-fs.target in addition to initrd-root-fs.target