### PR TITLE
dracut: include kernel modules and firmware

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -27,7 +27,6 @@ bad that happens will be less likely to hurt the host system. But no promises!
 DRACUT_ARGS=(
     --force
     --no-hostonly
-    --no-kernel
     --no-compress
     --omit i18n
     --omit lvm


### PR DESCRIPTION
This is necessary for supporting network cards in the initramfs.

Fixes https://github.com/coreos/bugs/issues/1263.