### PR TITLE
dracut: set ClientIdentifier=mac for the PXE OEM

### DIFF
--- a/dracut/02systemd-networkd/module-setup.sh
+++ b/dracut/02systemd-networkd/module-setup.sh
@@ -17,10 +17,13 @@ install() {
 
     inst_simple "$moddir/initrd-systemd-networkd.service" \
         "$systemdsystemunitdir/initrd-systemd-networkd.service"
-    
+
     inst_simple "$moddir/initrd-systemd-resolved.service" \
         "$systemdsystemunitdir/initrd-systemd-resolved.service"
-    
+
+    inst_simple "$moddir/yy-pxe.network" \
+        "$systemdutildir/network/yy-pxe.network"
+
     inst_simple "$moddir/zz-default.network" \
         "$systemdutildir/network/zz-default.network"
 

--- a/dracut/02systemd-networkd/yy-pxe.network
+++ b/dracut/02systemd-networkd/yy-pxe.network
@@ -1,0 +1,10 @@
+[Match]
+KernelCommandLine=!coreos.oem.id
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac
+UseMTU=true
+UseDomains=true


### PR DESCRIPTION
For coreos/bugs#1432, set the DHCP client identifier to the MAC address when using the PXE OEM.