### PR TITLE
dracut: change pxe network config condition

### DIFF
--- a/dracut/02systemd-networkd/yy-pxe.network
+++ b/dracut/02systemd-networkd/yy-pxe.network
@@ -1,5 +1,5 @@
 [Match]
-KernelCommandLine=!coreos.oem.id
+KernelCommandLine=!root
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
Using the MAC as the client identifier is needed when the machine-id is
transient. This almost always happens when the root filesystem is not
disk-backed (PXE booting). It's more accurate to check that the 'root'
kernel parameter is not specified, in which case a tmpfs will be
created.