### PR TITLE
dracut: install qemu_fw_cfg lkm in ignition module

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -22,3 +22,7 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 }
+
+installkernel() {
+    instmods qemu_fw_cfg
+}


### PR DESCRIPTION
This is needed until upstream includes qemu_fw_cfg in 90qemu.