### PR TITLE
dracut: include cdrom_id rules

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -21,6 +21,9 @@ install() {
 
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
+
+    inst_rules \
+        60-cdrom_id.rules
 }
 
 installkernel() {


### PR DESCRIPTION
This is needed to properly detect optical media and create the
/dev/disk/by-label symlinks for Ignition's OpenStack provider.