### PR TITLE
dracut: add network config for auto link local

### DIFF
--- a/dracut/03coreos-network/module-setup.sh
+++ b/dracut/03coreos-network/module-setup.sh
@@ -21,6 +21,9 @@ install() {
     inst_simple "$moddir/10-nodeps.conf" \
         "$systemdsystemunitdir/systemd-resolved.service.d/10-nodeps.conf"
 
+    inst_simple "$moddir/yy-linklocal.network" \
+        "$systemdutildir/network/yy-linklocal.network"
+
     inst_simple "$moddir/yy-pxe.network" \
         "$systemdutildir/network/yy-pxe.network"
 

--- a/dracut/03coreos-network/yy-linklocal.network
+++ b/dracut/03coreos-network/yy-linklocal.network
@@ -1,0 +1,7 @@
+[Match]
+KernelCommandLine=|coreos.oem.id=digitalocean
+KernelCommandLine=|coreos.oem.id=openstack
+
+[Network]
+DHCP=yes
+LinkLocalAddressing=yes


### PR DESCRIPTION
Both OpenStack and DigitalOcean require link-local auto-configuration in
order to communicate with the network metadata service.