### PR TITLE
dracut: add qemu detection to ignition generator

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -42,4 +42,9 @@ if [ -n "$RANDOMIZE_DISK_GUID" ]; then
     add_requires "disk-uuid@${escaped_guid}.service"
 fi
 
-echo "OEM_ID=$(cmdline_arg coreos.oem.id pxe)" > /run/ignition.env
+oem_id=pxe
+if [[ $(systemd-detect-virt || true) == "qemu" ]]; then
+    oem_id=qemu
+fi
+
+echo "OEM_ID=$(cmdline_arg coreos.oem.id ${oem_id})" > /run/ignition.env

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -13,6 +13,7 @@ install() {
         useradd \
         usermod \
         groupadd \
+        systemd-detect-virt \
         mkfs.btrfs \
         mkfs.ext4 \
         mkfs.xfs \


### PR DESCRIPTION
When run within QEMU, Ignition will now use the QEMU provider. Note that
this will not modify the kernel command line parameters, so later tools
will have to do their own detection.