### PR TITLE
dracut: include the default useradd configuration

### DIFF
--- a/dracut/99shadow/module-setup.sh
+++ b/dracut/99shadow/module-setup.sh
@@ -16,4 +16,11 @@ install() {
 
     cp -af "/usr/share/baselayout/gshadow" \
         "${initdir}/etc/gshadow"
+
+    # Include the default settings for useradd.
+    mkdir -p "${initdir}/etc/default"
+    cp -af "/usr/share/shadow/useradd" \
+        "${initdir}/etc/default/useradd"
+    cp -af "/usr/share/shadow/login.defs" \
+        "${initdir}/etc/login.defs"
 }


### PR DESCRIPTION
Since shadow 4.3 (65c26171), useradd reads its configuration before changing to the target root directory.  Use the same default values in the initramfs to avoid changes in behavior.