### PR TITLE
diskless-generator: Fix root directory mode 1777 on tmpfs

### DIFF
--- a/dracut/10diskless-generator/diskless-generator
+++ b/dracut/10diskless-generator/diskless-generator
@@ -68,7 +68,7 @@ Before=initrd-root-fs.target
 What=tmpfs
 Where=/sysroot
 Type=tmpfs
-Options=${rootflags:-mode=755}
+Options=mode=755${rootflags:+,$rootflags}
 EOF
 
 # Alternatively support using btrfs in ram instead of tmpfs


### PR DESCRIPTION
`rootflags` is typically set to `rw`, which was causing the mode option to disappear.  Later mode options override earlier ones, so it's still possible to set the mode from the kernel command line.

Reported in https://github.com/coreos/bugs/issues/1812.