### PR TITLE
dracut: Migrate Ignition unit files from coreos-overlay

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Ignition (disks)
+DefaultDependencies=false
+
+Requires=local-fs-pre.target
+Before=local-fs-pre.target
+
+# setup networking
+Wants=systemd-networkd.service
+After=systemd-networkd.service
+
+# generate resolv.conf
+Wants=systemd-resolved.service
+After=systemd-resolved.service
+
+# prevent racing with sgdisk and its subsequent udev activity
+After=disk-uuid.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=disks

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Ignition (files)
+DefaultDependencies=false
+Before=initrd-parse-etc.service
+
+Requires=initrd-root-fs.target
+After=initrd-root-fs.target
+
+Requires=ignition-disks.service
+After=ignition-disks.service
+
+# setup the root filesystem before we try do things like create users on it.
+Requires=initrd-setup-root.service
+After=initrd-setup-root.service
+
+# setup networking
+Wants=systemd-networkd.service
+After=systemd-networkd.service
+
+# generate resolv.conf
+Wants=systemd-resolved.service
+After=systemd-resolved.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=files

--- a/dracut/30ignition/ignition.target
+++ b/dracut/30ignition/ignition.target
@@ -1,0 +1,12 @@
+[Unit]
+DefaultDependencies=false
+Before=initrd-switch-root.target
+
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+
+Requires=ignition-disks.service
+After=ignition-disks.service
+
+Requires=ignition-files.service
+After=ignition-files.service

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -16,13 +16,19 @@ install() {
         systemd-detect-virt \
         mkfs.btrfs \
         mkfs.ext4 \
-        mkfs.xfs \
-        "$systemdsystemunitdir/ignition.target" \
-        "$systemdsystemunitdir/ignition-disks.service" \
-        "$systemdsystemunitdir/ignition-files.service"
+        mkfs.xfs
 
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
+
+    inst_simple "$moddir/ignition-disks.service" \
+        "$systemdsystemunitdir/ignition-disks.service"
+
+    inst_simple "$moddir/ignition-files.service" \
+        "$systemdsystemunitdir/ignition-files.service"
+
+    inst_simple "$moddir/ignition.target" \
+        "$systemdsystemunitdir/ignition.target"
 
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"


### PR DESCRIPTION
The Ignition units are intertwined with several other initramfs units maintained in bootengine, and are only useful when copied into the initramfs by the `30ignition` module.  Move them here for simplicity.

Unit files copied verbatim from coreos/coreos-overlay@fb0ebf975e572bae3486a515ac2887d39cd0a4f4.