### PR TITLE
dracut: Confirm entering emergency shell, reboot otherwise

### DIFF
--- a/dracut/99emergency-timeout/module-setup.sh
+++ b/dracut/99emergency-timeout/module-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    inst_hook emergency 99 "${moddir}/timeout.sh"
+}

--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -1,0 +1,42 @@
+# Before starting the emergency shell, prompt the user to press Enter.
+# If they don't, reboot the system.
+#
+# Assumes /bin/sh is bash.
+
+_prompt_for_timeout() {
+    local timeout=300
+    local interval=15
+
+    # Regularly prompt with time remaining.  This ensures the prompt doesn't
+    # get lost among kernel and systemd messages, and makes it clear what's
+    # going on if the user just connected a serial console.
+    while [[ $timeout > 0 ]]; do
+        local m=$(( $timeout / 60 ))
+        local s=$(( $timeout % 60 ))
+        local m_label="minutes"
+        if [[ $m = 1 ]]; then
+            m_label="minute"
+        fi
+
+        if [[ $s != 0 ]]; then
+            echo "Press Enter for emergency shell or wait $m $m_label $s seconds for reboot."
+        else
+            echo "Press Enter for emergency shell or wait $m $m_label for reboot."
+        fi
+
+        local anything
+        if read -t $interval anything; then
+            return
+        fi
+        timeout=$(( $timeout - $interval ))
+    done
+
+    echo "Rebooting."
+    # This is not very nice, but since reboot.target likely conflicts with
+    # the existing goal target wrt the desired state of shutdown.target,
+    # there doesn't seem to be a better option.
+    systemctl reboot --force
+    exit 0
+}
+
+_prompt_for_timeout


### PR DESCRIPTION
Add a hook to emergency shell launch which prompts the user to press Enter, and then reboots if there's no response within 5 minutes. This should prevent systems from being stuck forever at a prompt if there's a boot failure in the initramfs.