### PR TITLE
dracut: Delete /boot/coreos/first_boot after automatic Ignition run

### DIFF
--- a/dracut/30disk-uuid/disk-uuid@.service
+++ b/dracut/30disk-uuid/disk-uuid@.service
@@ -7,9 +7,7 @@ Wants=systemd-udevd.service
 After=systemd-udevd.service
 Requires=%i.device
 After=%i.device
-Requires=ignition-disks.service
-After=ignition-disks.service
-Before=verity-setup.service
+Before=ignition-disks.service verity-setup.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Ignition (disks)
 DefaultDependencies=false
-ConditionKernelCommandLine=coreos.first_boot=1
 
 Requires=local-fs-pre.target
 Before=local-fs-pre.target
@@ -21,6 +20,3 @@ After=disk-uuid.service
 Type=oneshot
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=disks
-
-[Install]
-RequiredBy=initrd.target

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -14,6 +14,9 @@ After=systemd-networkd.service
 Wants=systemd-resolved.service
 After=systemd-resolved.service
 
+# prevent racing with sgdisk and its subsequent udev activity
+After=disk-uuid.service
+
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Ignition (files)
 DefaultDependencies=false
-ConditionKernelCommandLine=coreos.first_boot=1
-
 Before=initrd-parse-etc.service
 
 Requires=initrd-root-fs.target
@@ -27,6 +25,3 @@ After=systemd-resolved.service
 Type=oneshot
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=files
-
-[Install]
-RequiredBy=initrd.target

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Ignition (files)
 DefaultDependencies=false
-ConditionPathExists=!/sysroot/etc/machine-id
+ConditionKernelCommandLine=coreos.first_boot=1
 
 Before=initrd-parse-etc.service
 

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -38,6 +38,10 @@ add_requires() {
 if $(cmdline_bool coreos.first_boot 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
+    # Only try to mount the ESP if GRUB detected a first_boot file
+    if [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
+        add_requires ignition-quench.service
+    fi
 fi
 
 RANDOMIZE_DISK_GUID=$(cmdline_arg coreos.randomize_disk_guid)

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -17,12 +17,25 @@ cmdline_arg() {
     echo "${value}"
 }
 
+cmdline_bool() {
+    local value=$(cmdline_arg "$@")
+    case "$value" in
+        ""|0|no|off) return 1;;
+        *) return 0;;
+    esac
+}
+
 add_requires() {
     local name="$1"
     local requires_dir="${UNIT_DIR}/initrd.target.requires"
     mkdir -p "${requires_dir}"
     ln -sf "../${name}" "${requires_dir}/${name}"
 }
+
+if $(cmdline_bool coreos.first_boot 0); then
+    add_requires ignition-disks.service
+    add_requires ignition-files.service
+fi
 
 RANDOMIZE_DISK_GUID=$(cmdline_arg coreos.randomize_disk_guid)
 if [ -n "$RANDOMIZE_DISK_GUID" ]; then

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -32,6 +32,9 @@ add_requires() {
     ln -sf "../${name}" "${requires_dir}/${name}"
 }
 
+# This can't be done with ConditionKernelCommandLine because that always
+# starts the unit's dependencies. We want to start networkd only on first
+# boot.
 if $(cmdline_bool coreos.first_boot 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service

--- a/dracut/30ignition/ignition-quench.service
+++ b/dracut/30ignition/ignition-quench.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Ignition (record completion)
+DefaultDependencies=false
+Before=initrd.target
+
+Requires=ignition-disks.service
+After=ignition-disks.service
+
+Requires=ignition-files.service
+After=ignition-files.service
+
+Requires=sysroot-boot.mount
+After=sysroot-boot.mount
+
+[Service]
+Type=oneshot
+# We will only run if GRUB detected this file. Fail if we are unable to
+# remove it, rather than risking rerunning Ignition at next boot.
+ExecStart=/bin/rm /sysroot/boot/coreos/first_boot

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -30,8 +30,6 @@ install() {
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"
 
-    systemctl --root "$initdir" enable ignition-disks.service
-    systemctl --root "$initdir" enable ignition-files.service
     systemctl --root "$initdir" enable coreos-digitalocean-network.service
 
     inst_rules \

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -27,6 +27,12 @@ install() {
     inst_simple "$moddir/ignition-files.service" \
         "$systemdsystemunitdir/ignition-files.service"
 
+    inst_simple "$moddir/ignition-quench.service" \
+        "$systemdsystemunitdir/ignition-quench.service"
+
+    inst_simple "$moddir/sysroot-boot.mount" \
+        "$systemdsystemunitdir/sysroot-boot.mount"
+
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"
 

--- a/dracut/30ignition/sysroot-boot.mount
+++ b/dracut/30ignition/sysroot-boot.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=/sysroot/boot
+
+Requisite=initrd-root-fs.target
+After=initrd-root-fs.target
+
+Conflicts=dracut-emergency.service emergency.service emergency.target
+Conflicts=initrd-switch-root.target
+
+[Mount]
+What=/dev/disk/by-label/EFI-SYSTEM
+Where=/sysroot/boot


### PR DESCRIPTION
GRUB [now detects the first boot using a flag file in the EFI partition](https://github.com/coreos/scripts/pull/651) and passes `coreos.first_boot=detected` if found. In this case, enable an extra unit to delete the flag file after Ignition runs successfully. This ensures that Ignition will run on every boot until it succeeds, without having to change the disk GUID late in the boot process.  Randomize the disk GUID when GRUB asks us to do so, but go back to doing it independently of any Ignition run.

If there is no flag file, or the ESP cannot be mounted, `coreos.first_boot=detected` will intentionally cause a boot failure. Ignition can still be manually invoked by passing `coreos.first_boot=1` and we will not try to delete the flag file in that case.