### PR TITLE
dracut: teach ignition-generator about kvm

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -31,7 +31,7 @@ if [ -n "$RANDOMIZE_DISK_GUID" ]; then
 fi
 
 oem_id=pxe
-if [[ $(systemd-detect-virt || true) == "qemu" ]]; then
+if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
     oem_id=qemu
 fi
 


### PR DESCRIPTION
Since systemd 233, a QEMU system using KVM has virtualization type "kvm", as opposed to the previous "qemu".  (It was back to "kvm" at some point several releases earlier.)  This sets the QEMU OEM ID value for both now, so Ignition is run on QEMU regardless of the systemd version or KVM support.