### PR TITLE
dracut: Fix emergency shell timeout with dracut breakpoints

### DIFF
--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -7,6 +7,10 @@ _prompt_for_timeout() {
     local timeout=300
     local interval=15
 
+    if [[ -e /.emergency-shell-confirmed ]]; then
+        return
+    fi
+
     # Regularly prompt with time remaining.  This ensures the prompt doesn't
     # get lost among kernel and systemd messages, and makes it clear what's
     # going on if the user just connected a serial console.
@@ -26,6 +30,7 @@ _prompt_for_timeout() {
 
         local anything
         if read -t $interval anything; then
+            > /.emergency-shell-confirmed
             return
         fi
         timeout=$(( $timeout - $interval ))

--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -39,4 +39,7 @@ _prompt_for_timeout() {
     exit 0
 }
 
-_prompt_for_timeout
+# If we're invoked from a dracut breakpoint rather than
+# dracut-emergency.service, we won't have a controlling terminal and stdio
+# won't be connected to it. Explicitly read/write /dev/console.
+_prompt_for_timeout < /dev/console > /dev/console


### PR DESCRIPTION
Require the user to press Enter only once, and give them time to do it.