### PR TITLE
dracut: added mkswap

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -17,7 +17,8 @@ install() {
         mountpoint \
         mkfs.btrfs \
         mkfs.ext4 \
-        mkfs.xfs
+        mkfs.xfs \
+        mkswap
 
     inst_script "$moddir/retry-umount.sh" \
         "/usr/sbin/retry-umount"


### PR DESCRIPTION
The `mkswap` binary needs to be in the initramfs for ignition to use.

Here's the related ignition PR to add support for using this: https://github.com/coreos/ignition/pull/354

Not sure this is the best way to add this, lmk if there's a better way to go about this.