### PR TITLE
add sysusers to the initramfs

### DIFF
--- a/dracut/20sysusers/ignition-sysusers.service
+++ b/dracut/20sysusers/ignition-sysusers.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Create System Users
+Documentation=man:sysusers.d(5) man:systemd-sysusers.service(8)
+DefaultDependencies=no
+
+# setup the root filesystem before we create users/groups on it
+Requires=initrd-setup-root.service
+After=initrd-setup-root.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/systemd-sysusers --root=/sysroot
+TimeoutSec=90s

--- a/dracut/20sysusers/module-setup.sh
+++ b/dracut/20sysusers/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd
+}
+
+install() {
+    inst_multiple systemd-sysusers
+    inst_simple "$moddir/ignition-sysusers.service" \
+        "$systemdsystemunitdir/ignition-sysusers.service"
+    systemctl --root "$initdir" enable ignition-sysusers.service
+}

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -13,6 +13,10 @@ After=ignition-disks.service
 Requires=initrd-setup-root.service
 After=initrd-setup-root.service
 
+# run sysusers first, so we can reference created users and groups
+Requires=ignition-sysusers.service
+After=ignition-sysusers.service
+
 # setup networking
 Wants=systemd-networkd.service
 After=systemd-networkd.service

--- a/dracut/99shadow/module-setup.sh
+++ b/dracut/99shadow/module-setup.sh
@@ -3,17 +3,10 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
 install() {
-    # Simply pull in all the shadow db files so things like systemd-tmpfiles
+    # Run systemd-sysusers during the build so things like systemd-tmpfiles
     # will always be able to find users referenced by the baselayout files.
-    cp -af "/usr/share/baselayout/passwd" \
-        "${initdir}/etc/passwd"
+    cp -ar "/usr/lib/sysusers.d" \
+        "${initdir}/usr/lib/"
 
-    cp -af "/usr/share/baselayout/shadow" \
-        "${initdir}/etc/shadow"
-
-    cp -af "/usr/share/baselayout/group" \
-        "${initdir}/etc/group"
-
-    cp -af "/usr/share/baselayout/gshadow" \
-        "${initdir}/etc/gshadow"
+    systemd-sysusers --root="${initdir}"
 }


### PR DESCRIPTION
This commit does two things:
- Modify `dracut/99shadow/module-setup.sh` to run `systemd-sysusers`
  during the dracut build to add user/group definitions to the
  initramfs.
- Adds `systemd-sysusers` to the initramfs, and runs it before the
  `ignition-files.service` unit. This is so that ignition can reference
  and modify created users and groups.

Dependent on https://github.com/coreos/baselayout/pull/64