### PR TITLE
dracut: on ec2, disable systemd-networkd if ignition fails

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -42,6 +42,18 @@ if $(cmdline_bool coreos.first_boot 0); then
     if [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
         add_requires ignition-quench.service
     fi
+
+    # On EC2, shut down systemd-networkd if ignition fails so that the instance
+    # fails EC2 instance checks.
+    if [[ $(cmdline_arg coreos.oem.id) == "ec2" ]]; then
+        mkdir -p ${UNIT_DIR}/systemd-networkd.service.d
+        cat > ${UNIT_DIR}/systemd-networkd.service.d/10-conflict-emergency.conf <<EOF
+[Unit]
+Conflicts=emergency.target
+Conflicts=emergency.service
+Conflicts=dracut-emergency.service
+EOF
+    fi
 fi
 
 RANDOMIZE_DISK_GUID=$(cmdline_arg coreos.randomize_disk_guid)


### PR DESCRIPTION
If ignition fails when running on EC2, systemd-networkd should be stopped so that the instance's status checks fail and indicate ignition's failure.

Fixes coreos/bugs#1890.