### PR TITLE
dracut: Use coreos-metadata to configure Packet networking on first boot

### DIFF
--- a/dracut/30ignition/coreos-static-network.service
+++ b/dracut/30ignition/coreos-static-network.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CoreOS Static Network Agent
+DefaultDependencies=false
+Before=initrd.target
+After=systemd-networkd.service initrd-root-fs.target
+Wants=systemd-networkd.service initrd-root-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/sysroot/etc/systemd/network/ --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -42,6 +42,9 @@ if $(cmdline_bool coreos.first_boot 0); then
     if [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
         add_requires ignition-quench.service
     fi
+    if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
+        add_requires coreos-static-network.service
+    fi
 
     # On EC2, shut down systemd-networkd if ignition fails so that the instance
     # fails EC2 instance checks.

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -43,6 +43,9 @@ install() {
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"
 
+    inst_simple "$moddir/coreos-static-network.service" \
+        "$systemdsystemunitdir/coreos-static-network.service"
+
     inst_rules \
         60-cdrom_id.rules
 }


### PR DESCRIPTION
Name the service `coreos-static-network.service` because there's nothing Packet-specific about its definition.  Probably `coreos-digitalocean-network.service` should be renamed to `coreos-dynamic-network.service` but that might break someone's journal monitoring.

Depends on https://github.com/coreos/coreos-metadata/pull/51.