### PR TITLE
dracut: Run coreos-static-network before ignition-files

### DIFF
--- a/dracut/30ignition/coreos-static-network.service
+++ b/dracut/30ignition/coreos-static-network.service
@@ -5,6 +5,9 @@ Before=initrd.target
 After=systemd-networkd.service initrd-root-fs.target
 Wants=systemd-networkd.service initrd-root-fs.target
 
+# Ensure Ignition can overwrite /etc/hostname
+Before=ignition-files.service
+
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/coreos-metadata --cmdline --network-units=/sysroot/etc/systemd/network/ --hostname=/sysroot/etc/hostname


### PR DESCRIPTION
Ensure ignition-files can overwrite `/etc/hostname` (and potentially the networkd units). Fixes `coreos.ignition.*.sethostname` and `systemd.journal.remote` kola tests.

We do not do the same for coreos-digitalocean-network because that runs on every boot, so it'll have the last word anyway.