### PR TITLE
dracut: prevent dev-mapper-usr.device from timing out

### DIFF
--- a/dracut/10verity-generator/module-setup.sh
+++ b/dracut/10verity-generator/module-setup.sh
@@ -10,4 +10,11 @@ install() {
     inst_multiple veritysetup e2size systemd-escape tr
     inst_simple "$moddir/verity-generator" \
         "$systemdutildir/system-generators/verity-generator"
+
+    # Device units default to a finite JobRunningTimeout, which would cause
+    # dev-mapper-usr.device to fail if its dependencies took too long to
+    # start. This was causing boot failures when Ignition was asked to
+    # format multiple large filesystems.
+    inst_simple "$moddir/no-job-timeout.conf" \
+        "$systemdsystemunitdir/dev-mapper-usr.device.d/no-job-timeout.conf"
 }

--- a/dracut/10verity-generator/no-job-timeout.conf
+++ b/dracut/10verity-generator/no-job-timeout.conf
@@ -1,0 +1,2 @@
+[Unit]
+JobRunningTimeoutSec=infinity


### PR DESCRIPTION
`dev-mapper-usr.device` has a 90-second job timeout by default and is indirectly ordered after `ignition-disks.service` via `verity-setup.service`. As a result, long-running ignition-disks jobs would cause boot failures. Use an infinite timeout instead.

Addresses https://github.com/coreos/bugs/issues/2026.