### PR TITLE
dracut: fail verity-setup.service if verity setup fails

### DIFF
--- a/dracut/10verity-generator/verity-generator
+++ b/dracut/10verity-generator/verity-generator
@@ -75,6 +75,11 @@ if [[ -n "${usr}" && -n "${usrhash}" ]]; then
 	Type=oneshot
 	RemainAfterExit=yes
 	ExecStart=/bin/sh -c '/sbin/veritysetup create usr --hash-offset="\$(e2size ${usr})" "${usr}" "${usr}" "${usrhash}"'
+	# If there's a hash mismatch during table initialization,
+	# veritysetup reports it on stderr but still exits 0, and
+	# dev-mapper-usr.device ends up waiting indefinitely. Manually
+	# check the target status and fail if invalid.
+	ExecStart=/bin/bash -c 'read off len tgt status addl <<<\$(dmsetup status usr); [[ "\$\${status}" == V ]]'
 	ExecStop=/sbin/veritysetup remove usr
 	EOF
 


### PR DESCRIPTION
863b403ff8537ccb8f21fd481892512f7c7f5452 removes the job timeout from `dev-mapper-usr.device`, but that timeout was the only thing causing us to drop to an emergency shell (and eventually reboot) if the verity root hash doesn't match the `/usr` partition. veritysetup detects this case and reports it to stderr but exits zero anyway; `dev-mapper-usr.device` then fails to finish starting for reasons that are not clear to me (the device node exists, can be opened, and reads properly return I/O errors). Fix by explicitly checking the verity status in the dm table. This should be race-free: we don't refer to the dm device by its device node, and we're performing the same status check that veritysetup performs at the end of its execution.