### PR TITLE
update-bootengine: enable terminfo module

### DIFF
--- a/update-bootengine
+++ b/update-bootengine
@@ -33,7 +33,6 @@ DRACUT_ARGS=(
     --omit lvm
     --omit multipath
     --omit network
-    --omit terminfo
     )
 
 SETUP_MOUNTS=


### PR DESCRIPTION
It prevents systemctl status and journalctl from complaining when run from the emergency shell:

    WARNING: terminal is not fully functional
    -  (press RETURN)

The cost is 6 KiB of image size.