### PR TITLE
dracut: add module to start iSCSI root disk

### DIFF
--- a/dracut/03coreos-network/10-down.conf
+++ b/dracut/03coreos-network/10-down.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStop=/usr/bin/ip addr flush up
-ExecStop=/usr/bin/ip link set group default down

--- a/dracut/03coreos-network/module-setup.sh
+++ b/dracut/03coreos-network/module-setup.sh
@@ -24,6 +24,12 @@ install() {
     inst_simple "$moddir/yy-digitalocean.network" \
         "$systemdutildir/network/yy-digitalocean.network"
 
+    inst_simple "$moddir/yy-oracle-oci.network" \
+        "$systemdutildir/network/yy-oracle-oci.network"
+
+    inst_simple "$moddir/yy-oracle-oci-bm.network" \
+        "$systemdutildir/network/yy-oracle-oci-bm.network"
+
     inst_simple "$moddir/yy-pxe.network" \
         "$systemdutildir/network/yy-pxe.network"
 

--- a/dracut/03coreos-network/module-setup.sh
+++ b/dracut/03coreos-network/module-setup.sh
@@ -15,8 +15,8 @@ install() {
         $systemdsystemunitdir/systemd-resolved.service \
         /etc/systemd/resolved.conf
 
-    inst_simple "$moddir/10-down.conf" \
-        "$systemdsystemunitdir/systemd-networkd.service.d/10-down.conf"
+    inst_simple "$moddir/network-cleanup.service" \
+        "$systemdsystemunitdir/network-cleanup.service"
 
     inst_simple "$moddir/10-nodeps.conf" \
         "$systemdsystemunitdir/systemd-resolved.service.d/10-nodeps.conf"
@@ -48,4 +48,6 @@ install() {
     # we only want it when pulled in
     systemctl --root "$initdir" disable systemd-networkd.service
     systemctl --root "$initdir" disable systemd-networkd.socket
+
+    systemctl --root "$initdir" enable network-cleanup.service
 }

--- a/dracut/03coreos-network/network-cleanup.service
+++ b/dracut/03coreos-network/network-cleanup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Network Cleanup
+DefaultDependencies=false
+RefuseManualStart=true
+RefuseManualStop=true
+# Oracle OCI accesses root over iSCSI, so we can't tear down the network
+ConditionKernelCommandLine=!coreos.oem.id=oracle-oci
+
+PartOf=systemd-networkd.service
+Before=systemd-networkd.service
+
+[Service]
+RemainAfterExit=true
+ExecStop=/usr/bin/ip addr flush up
+ExecStop=/usr/bin/ip link set group default down
+
+[Install]
+WantedBy=systemd-networkd.service

--- a/dracut/03coreos-network/yy-oracle-oci-bm.network
+++ b/dracut/03coreos-network/yy-oracle-oci-bm.network
@@ -1,0 +1,14 @@
+[Match]
+KernelCommandLine=coreos.oem.id=oracle-oci
+# ixgbevf (in VMs) doesn't reset the NIC on MTU change
+# https://github.com/coreos/bugs/issues/2031
+Driver=!ixgbevf
+
+[Network]
+DHCP=yes
+
+[DHCP]
+UseMTU=false
+UseDomains=true
+# Root is on iSCSI
+CriticalConnection=true

--- a/dracut/03coreos-network/yy-oracle-oci.network
+++ b/dracut/03coreos-network/yy-oracle-oci.network
@@ -1,0 +1,14 @@
+[Match]
+KernelCommandLine=coreos.oem.id=oracle-oci
+# ixgbevf (in VMs) doesn't reset the NIC on MTU change
+# https://github.com/coreos/bugs/issues/2031
+Driver=ixgbevf
+
+[Network]
+DHCP=yes
+
+[DHCP]
+UseMTU=true
+UseDomains=true
+# Root is on iSCSI
+CriticalConnection=true

--- a/dracut/90iscsi-root/iscsi-root-generator
+++ b/dracut/90iscsi-root/iscsi-root-generator
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -e
+
+UNIT_DIR="${1:-/tmp}"
+
+cmdline=( $(</proc/cmdline) )
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+add_requires() {
+    local name="$1"
+    local requires_dir="${UNIT_DIR}/basic.target.requires"
+    mkdir -p "${requires_dir}"
+    ln -sf "../${name}" "${requires_dir}/${name}"
+}
+
+# This can't be done with ConditionKernelCommandLine because that always
+# starts the unit's dependencies.
+if [[ $(cmdline_arg coreos.oem.id) == "oracle-oci" ]]; then
+    add_requires oracle-oci-root.service
+fi

--- a/dracut/90iscsi-root/module-setup.sh
+++ b/dracut/90iscsi-root/module-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo coreos-network
+}
+
+installkernel() {
+    instmods iscsi_tcp crc32c
+}
+
+install() {
+    inst_multiple iscsistart
+
+    inst_simple "$moddir/oracle-oci-root.service" \
+        "$systemdutildir/system/oracle-oci-root.service"
+
+    inst_simple "$moddir/iscsi-root-generator" \
+        "$systemdutildir/system-generators/iscsi-root-generator"
+}

--- a/dracut/90iscsi-root/oracle-oci-root.service
+++ b/dracut/90iscsi-root/oracle-oci-root.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Oracle OCI Root Disk
+DefaultDependencies=false
+
+Before=basic.target
+
+# setup networking
+Wants=systemd-networkd.service
+After=systemd-networkd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/iscsistart -i iqn.2015-02.oracle.boot:instance -t iqn.2015-02.oracle.boot:uefi -a 169.254.0.2 -g 1


### PR DESCRIPTION
The upstream Dracut `iscsi` module is much more than we need, and would require several workarounds for CL. For now, support only Oracle OCI in a hardcoded way.

For https://github.com/coreos/bugs/issues/2036.