### PR TITLE
99start-root: drop DEVLINKS from mdadm invocation

### DIFF
--- a/dracut/99start-root/65-start-root.rules
+++ b/dracut/99start-root/65-start-root.rules
@@ -32,7 +32,7 @@ LABEL="start_root"
 # but this ensures ID_PART_ENTRY_TYPE is in the environment and is set by the builtin blkid.
 IMPORT{builtin}="blkid"
 # If it's the root-on-raid GUID, start the raid
-ENV{ID_PART_ENTRY_TYPE}=="be9067b9-ea49-4f15-b4f6-f36f8c9e1818", ACTION=="add|change", IMPORT{program}="/sbin/mdadm --incremental --export $devnode --offroot ${DEVLINKS}"
+ENV{ID_PART_ENTRY_TYPE}=="be9067b9-ea49-4f15-b4f6-f36f8c9e1818", ACTION=="add|change", IMPORT{program}="/sbin/mdadm --incremental --export --offroot $devnode"
 # Handle other (future) cases here
 
 LABEL="start_root_end"


### PR DESCRIPTION
Currently testing, don't merge just yet

The current invocation is broken (should be $env{DEVLINKS}) and
pointless, so drop it. The last arguments to the `mdadm --incremental`
command are just aliases that can be used in /etc/mdadm.conf (see the
"INCREMENTAL MODE" section of man 8 mdadm). We don't use
/etc/mdadm.conf in the initramfs, so just drop it.

cc @lucab since he was curious about this