### PR TITLE
dracut: drop obsolete comment

### DIFF
--- a/dracut/03coreos-network/yy-oracle-oci.network
+++ b/dracut/03coreos-network/yy-oracle-oci.network
@@ -8,6 +8,4 @@ DHCP=yes
 UseMTU=true
 UseDomains=true
 # Root is on iSCSI
-# Also prevents networkd from repeatedly resetting the MTU on bare metal
-# https://github.com/coreos/bugs/issues/2031
 CriticalConnection=true


### PR DESCRIPTION
Fixed upstream in systemd/systemd@e1c42e1b4097d575d8ac2222b2cc656fa256166b.