### PR TITLE
dracut/99emergency-timeout: print explainer when Ignition fails

### DIFF
--- a/dracut/99emergency-timeout/module-setup.sh
+++ b/dracut/99emergency-timeout/module-setup.sh
@@ -3,5 +3,9 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
 install() {
+    inst_multiple \
+        cut \
+        date
+
     inst_hook emergency 99 "${moddir}/timeout.sh"
 }


### PR DESCRIPTION
When timeout.sh is run due to a failed boot, check if either the ignition-disks or ignition-files units have failed. If they have, wait until journalctl has stopped receiving messages and then reprint the failed logs. Also print the emergency shell prompt via `\r` instead of `\n` so it doesn't slowly push the Ignition logs off the screen.

Waiting until journalctl has stopped receiving messages for 5 seconds (with a 15 second timeout) is a workaround for not being able to prevent systemd from printing to the console once the failure state is reached.

The motivation for this is to make it more obvious to users what went wrong when a machine fails to boot due to a bad Ignition config.

What this looks like in practice:

In QEMU:
![2018-03-01_15 29 44_3200x1800_scrot](https://user-images.githubusercontent.com/2439413/36876468-0af81eea-1d6a-11e8-93d9-da01d73b6d2b.png)


In EC2:
![2018-03-01_15 59 53_3200x1800_scrot](https://user-images.githubusercontent.com/2439413/36876481-1af422ee-1d6a-11e8-9397-4a1e8b87eece.png)
![2018-03-01_15 59 57_3200x1800_scrot](https://user-images.githubusercontent.com/2439413/36876484-1cd89482-1d6a-11e8-88cb-de6c200472f2.png)
