### PR TITLE
dracut: add torcx-profile-populate service

### DIFF
--- a/dracut/35torcx/module-setup.sh
+++ b/dracut/35torcx/module-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo ignition
+}
+
+install() {
+    inst_simple "$moddir/torcx-profile-populate-generator" \
+        "$systemdutildir/system-generators/torcx-profile-populate-generator"
+
+    inst_simple "${moddir}/torcx-profile-populate.service" \
+        "${systemdsystemunitdir}/torcx-profile-populate.service"
+}

--- a/dracut/35torcx/torcx-profile-populate-generator
+++ b/dracut/35torcx/torcx-profile-populate-generator
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -e
+
+UNIT_DIR="${1:-/tmp}"
+
+cmdline=( $(</proc/cmdline) )
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+cmdline_bool() {
+    local value=$(cmdline_arg "$@")
+    case "$value" in
+        ""|0|no|off) return 1;;
+        *) return 0;;
+    esac
+}
+
+add_requires() {
+    local name="$1"
+    local requires_dir="${UNIT_DIR}/initrd.target.requires"
+    mkdir -p "${requires_dir}"
+    ln -sf "../${name}" "${requires_dir}/${name}"
+}
+
+# This can't be done with ConditionKernelCommandLine because that always
+# starts the unit's dependencies. We want to start networkd only on first
+# boot.
+if $(cmdline_bool coreos.first_boot 0); then
+    add_requires torcx-profile-populate.service
+fi

--- a/dracut/35torcx/torcx-profile-populate.service
+++ b/dracut/35torcx/torcx-profile-populate.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Populate torcx store to satisfy profile
+DefaultDependencies=false
+
+# Requires ESP mounted at /sysroot/boot to check for first_boot
+Requires=sysroot-boot.service
+After=sysroot-boot.service
+
+# Requires files provisioning by ignition
+Requires=ignition-setup.service ignition-disks.service ignition-files.service
+After=ignition-setup.service ignition-disks.service ignition-files.service
+
+# Requires real rootfs at /sysroot to consume torcx config
+Requires=initrd-setup-root.service initrd-root-fs.target
+After=initrd-setup-root.service initrd-root-fs.target
+
+# Requires networking for downloading archives
+Wants=systemd-networkd.service
+After=systemd-networkd.service
+
+# Requires DNS resolution for remotes
+Wants=systemd-resolved.service
+After=systemd-resolved.service
+
+# Runs before initramfs provisioning is completed.
+Before=ignition-quench.service initrd-parse-etc.service
+
+[Install]
+RequiredBy=ignition-quench.service
+
+[Service]
+Type=oneshot
+Environment=TORCX_VERBOSE=info
+EnvironmentFile=-/sysroot/etc/environment
+EnvironmentFile=/sysroot/usr/lib/os-release
+BindReadOnlyPaths=/etc/resolv.conf
+RootDirectory=/sysroot
+ExecStart=/bin/bash -c "if [ -e /etc/torcx/next-profile ]; then /usr/lib/coreos/torcx profile populate -v=${TORCX_VERBOSE} -n ${VERSION_ID}; fi"


### PR DESCRIPTION
This adds a new `35torcx` module to bootengine, which takes care of
bringing `torcx-profile-populate.service` into initramfs.