### PR TITLE
35torcx: remove unused dependency on sysroot-boot

### DIFF
--- a/dracut/35torcx/torcx-profile-populate.service
+++ b/dracut/35torcx/torcx-profile-populate.service
@@ -3,10 +3,6 @@ Description=Populate torcx store to satisfy profile
 DefaultDependencies=false
 ConditionPathExists=/sysroot/etc/torcx/next-profile
 
-# Requires ESP mounted at /sysroot/boot to check for first_boot
-Requires=sysroot-boot.service
-After=sysroot-boot.service
-
 # Requires files provisioning by ignition
 Requires=ignition-setup.service ignition-disks.service ignition-files.service
 After=ignition-setup.service ignition-disks.service ignition-files.service


### PR DESCRIPTION
This removes the dependency on `sysroot-boot` from
`torcx-profile-populate`, as the linked EFI-SYSTEM device is not
available on diskless PXE nodes.

The dependency itself is a leftover from a previous `ConditionPathExists`
for `first_boot` gating, which instead is now handled by `torcx-profile-populate-generator`.
Thus it should be safe to simply drop.

Ref: https://github.com/coreos/bugs/issues/2491