### PR TITLE
Add udev rules for Azure disks

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -49,5 +49,6 @@ install() {
         "$systemdsystemunitdir/coreos-static-network.service"
 
     inst_rules \
-        60-cdrom_id.rules
+        60-cdrom_id.rules \
+        66-azure-storage.rules
 }


### PR DESCRIPTION
Fixes: https://github.com/coreos/bugs/issues/2481

This change allows to use proper Azure disk paths in ignition.