### PR TITLE
dracut: add hetzner cloud support

### DIFF
--- a/dracut/30ignition/coreos-hcloud-hostname.service
+++ b/dracut/30ignition/coreos-hcloud-hostname.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CoreOS Hetzner Cloud Hostname Agent
+DefaultDependencies=false
+Before=initrd.target
+After=systemd-networkd.service initrd-root-fs.target
+Wants=systemd-networkd.service initrd-root-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/coreos-metadata --cmdline --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/coreos-static-hostname.service
+++ b/dracut/30ignition/coreos-static-hostname.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=CoreOS Hetzner Cloud Hostname Agent
+Description=CoreOS Static Hostname Agent
 DefaultDependencies=false
 Before=initrd.target
 After=systemd-networkd.service initrd-root-fs.target

--- a/dracut/30ignition/coreos-static-hostname.service
+++ b/dracut/30ignition/coreos-static-hostname.service
@@ -5,6 +5,9 @@ Before=initrd.target
 After=systemd-networkd.service initrd-root-fs.target
 Wants=systemd-networkd.service initrd-root-fs.target
 
+# Ensure Ignition can overwrite /etc/hostname
+Before=ignition-files.service
+
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/coreos-metadata --cmdline --hostname=/sysroot/etc/hostname

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -97,6 +97,10 @@ if [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]]; then
     add_requires coreos-digitalocean-network.service
 fi
 
+if [[ $(cmdline_arg coreos.oem.id) == "hcloud" ]]; then
+    add_requires coreos-hcloud-hostname.service
+fi
+
 oem_id=pxe
 if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
     oem_id=qemu

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -45,6 +45,9 @@ if $(cmdline_bool coreos.first_boot 0); then
     if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
         add_requires coreos-static-network.service
     fi
+    if [[ $(cmdline_arg coreos.oem.id) == "hcloud" ]]; then
+        add_requires coreos-static-hostname.service
+    fi
 
     # On EC2, shut down systemd-networkd if ignition fails so that the instance
     # fails EC2 instance checks.
@@ -95,10 +98,6 @@ fi
 
 if [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]]; then
     add_requires coreos-digitalocean-network.service
-fi
-
-if [[ $(cmdline_arg coreos.oem.id) == "hcloud" ]]; then
-    add_requires coreos-hcloud-hostname.service
 fi
 
 oem_id=pxe

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -49,6 +49,9 @@ install() {
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"
 
+    inst_simple "$moddir/coreos-hcloud-hostname.service" \
+        "$systemdsystemunitdir/coreos-hcloud-hostname.service"    
+
     inst_simple "$moddir/coreos-static-network.service" \
         "$systemdsystemunitdir/coreos-static-network.service"
 

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -49,8 +49,8 @@ install() {
     inst_simple "$moddir/coreos-digitalocean-network.service" \
         "$systemdsystemunitdir/coreos-digitalocean-network.service"
 
-    inst_simple "$moddir/coreos-hcloud-hostname.service" \
-        "$systemdsystemunitdir/coreos-hcloud-hostname.service"    
+    inst_simple "$moddir/coreos-static-hostname.service" \
+        "$systemdsystemunitdir/coreos-static-hostname.service"    
 
     inst_simple "$moddir/coreos-static-network.service" \
         "$systemdsystemunitdir/coreos-static-network.service"


### PR DESCRIPTION
Along with:
- https://github.com/coreos/coreos-metadata/pull/125
- https://github.com/coreos/ignition/pull/667
- https://github.com/coreos/scripts/pull/859
- https://github.com/coreos/coreos-overlay/pull/3490
- https://github.com/coreos/container-linux-config-transpiler/pull/164

This will greatly enhance working with CoreOS on the Hetzner Cloud.